### PR TITLE
Specify Cabal-Version in cabal file

### DIFF
--- a/magic.cabal
+++ b/magic.cabal
@@ -3,6 +3,7 @@ Extra-Libraries: magic
 -- need editing.
 Name: magic
 Version: 1.1
+Cabal-Version: >= 1.8
 license: BSD3
 Maintainer: John Goerzen <jgoerzen@complete.org>
 Author: John Goerzen


### PR DESCRIPTION
Hopefully this suppresses the following warning:
```
Warning: magic.cabal:27:28: version operators used. To use version operators
the package needs to specify at least 'cabal-version: >= 1.8'.
```