### PR TITLE
Don't use `unsafe` FFI calls for blocking I/O

### DIFF
--- a/Magic/Operations.hsc
+++ b/Magic/Operations.hsc
@@ -89,14 +89,18 @@ magicCompile m mstr = withMagicPtr m (\cm ->
                                      )
     where worker cm cs = checkIntError "magicCompile" m $ magic_compile cm cs
 
-foreign import ccall unsafe "magic.h magic_file"
+-- Does file I/O -> safe
+foreign import ccall safe "magic.h magic_file"
   magic_file :: Ptr CMagic -> CString -> IO CString
 
+-- Does not do I/O -> unsafe
 foreign import ccall unsafe "magic.h magic_buffer"
   magic_buffer :: Ptr CMagic -> CString -> #{type size_t} -> IO CString
 
+-- Does not do I/O -> unsafe
 foreign import ccall unsafe "magic.h magic_setflags"
   magic_setflags :: Ptr CMagic -> CInt -> IO CInt
 
-foreign import ccall unsafe "magic.h magic_compile"
+-- Does file I/O -> safe
+foreign import ccall safe "magic.h magic_compile"
   magic_compile :: Ptr CMagic -> CString -> IO CInt


### PR DESCRIPTION
`unsafe` must not be used with blocking I/O. `safe` is designed for this.

Fixes e.g. `magicFile` blocking a whole capability (OS thread) while reading file contents, thus destroying Haskell's green threading, even more so on networked file systems.